### PR TITLE
fix: print tracebacks for per-item failures in batch generation loops

### DIFF
--- a/infer_helios.py
+++ b/infer_helios.py
@@ -7,6 +7,7 @@ os.environ["HF_PARALLEL_LOADING_WORKERS"] = "8"
 
 import argparse
 import time
+import traceback
 
 import pandas as pd
 import torch
@@ -376,6 +377,7 @@ def main():
                         interpolate_time_list=interpolate_time_list,
                     ).frames[0]
                 except Exception:
+                    traceback.print_exc()
                     continue
             if not args.enable_parallelism or rank == 0:
                 export_to_video(output, output_path, fps=24)
@@ -434,6 +436,7 @@ def main():
                         interpolate_time_list=interpolate_time_list,
                     ).frames[0]
                 except Exception:
+                    traceback.print_exc()
                     continue
             if not args.enable_parallelism or rank == 0:
                 export_to_video(output, output_path, fps=24)
@@ -503,6 +506,7 @@ def main():
                         interpolate_time_list=interpolate_time_list,
                     ).frames[0]
                 except Exception:
+                    traceback.print_exc()
                     continue
             if not args.enable_parallelism or rank == 0:
                 export_to_video(output, output_path, fps=24)


### PR DESCRIPTION
## What

Adds `traceback.print_exc()` before each of the three per-item `except Exception: continue` handlers in `infer_helios.py`'s batch modes (prompt_txt / image_prompt_csv / interactive_csv), plus the `import traceback`.

## Why

A failing item currently leaves no trace: the process exits 0 with fewer (or zero) outputs after minutes of GPU time. Observed in practice: an interactive run OOM'd at the final postprocess after ~10 minutes and was indistinguishable from success at the process level — `echo $?` → `0`, output folder empty.

## Compatibility / regression

- Keeps the author-intended skip-and-continue batch semantics; smallest possible change.
- stderr output only; no API/behavior/exit-code change.
- Deliberately separate from the interactive chunk-count fix (unrelated concerns); together they turn that failure from "exit 0, no files" into a visible OOM with a traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
