### PR TITLE
docs: replace removed `huggingface-cli` with `hf` in model download commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ bash install.sh
 Download models using huggingface-cli:
 ``` sh
 pip install "huggingface_hub[cli]"
-huggingface-cli download BestWishYSH/Helios-Base --local-dir BestWishYSH/Helios-Base
-huggingface-cli download BestWishYSH/Helios-Mid --local-dir BestWishYSH/Helios-Mid
-huggingface-cli download BestWishYSH/Helios-Distilled --local-dir BestWishYSH/Helios-Distilled
+hf download BestWishYSH/Helios-Base --local-dir BestWishYSH/Helios-Base
+hf download BestWishYSH/Helios-Mid --local-dir BestWishYSH/Helios-Mid
+hf download BestWishYSH/Helios-Distilled --local-dir BestWishYSH/Helios-Distilled
 ```
 
 Download models using modelscope-cli:


### PR DESCRIPTION
## What

Replaces the three `huggingface-cli download` commands in the README's *Model Download* section with `hf download` (identical arguments).

## Why

`requirements.txt` pins `huggingface-hub==1.4.1`, and huggingface_hub ≥ 1.0 removed the legacy `huggingface-cli` entry point (the CLI is now `hf`). Following the README verbatim in the documented environment fails with `command not found`. `eval/checkpoints/get_checkpoints.sh` already uses `hf download` — this aligns the README with it.

## Compatibility

Documentation only. `hf download` accepts the same arguments; users on hub < 1.0 (outside the repo's pins) can still use the old name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
