### PR TITLE
fix(train): drop the stray stage2_num_inference_steps_list kwarg from the _ode_regression_loss call

### DIFF
--- a/train_helios.py
+++ b/train_helios.py
@@ -1502,7 +1502,6 @@ def main(args):
                                 history_sizes=args.training_config.history_sizes,
                                 # For Stage 2
                                 stage2_num_stages=args.training_config.stage2_num_stages,
-                                stage2_num_inference_steps_list=args.validation_config.stage2_simulated_inference_steps,
                                 # For ODE Main
                                 last_step_only=args.training_config.dmd_last_step_only,
                                 use_dynamic_shifting=args.training_config.use_dynamic_shifting,


### PR DESCRIPTION
### What

`train_helios.py:1505` passes `stage2_num_inference_steps_list=` to `_ode_regression_loss()`,
which has no such parameter and no `**kwargs`:

```
TypeError: _ode_regression_loss() got an unexpected keyword argument 'stage2_num_inference_steps_list'
```

### Evidence that the kwarg is the mistake (not a missing parameter)

The **other** `_ode_regression_loss` call site in the same file — the
`is_only_ode_regression` branch at `train_helios.py:1395` — is otherwise identical
argument-for-argument and correctly stops at `stage2_num_stages`:

```python
                        # For Stage 2
                        stage2_num_stages=args.training_config.stage2_num_stages,
                        # For ODE Main
                        last_step_only=args.training_config.dmd_last_step_only,
```

And the function genuinely does not need it: the per-stage step count inside
`_ode_regression_loss` comes from the pre-computed ODE trajectory
(`ode_latents[k][i_s]["timesteps"].shape[0]`), not from a caller-supplied list. The
only thing it takes from the stage-2 config is `stage2_num_stages`, which it asserts
against `len(ode_latents[0])`.

The line looks copy-pasted from the `_generator_loss(...)` block immediately below it
(`:1548`) — `_generator_loss` *does* accept `stage2_num_inference_steps_list`, so that
call site is fine and is left alone.

### When it fires

The broken branch is `is_use_ode_regression=True` **and** `is_only_ode_regression=False`
(ODE regression combined with DMD/GAN generator training), inside `if TRAIN_GENERATOR:`.
The shipped `scripts/training/configs/stage_3_ode.yaml` sets `is_only_ode_regression: true`,
so it takes the *working* branch — which is presumably why this has gone unnoticed. Anyone
who enables ODE regression alongside DMD hits it on the first generator step.

### Verification

No GPU here, so I checked the binding statically: parsed
`helios/utils/utils_helios_post.py`, built stubs from the real `ast.arguments` of
`_ode_regression_loss` / `_generator_loss`, and `inspect.Signature.bind`-ed every call
site in `train_helios.py`, keeping the two known-good sites as a control group.

Before:

```
line 1395  _ode_regression_loss   OK
line 1527  _generator_loss        OK
line 1491  _ode_regression_loss   FAIL -> TypeError: got an unexpected keyword argument 'stage2_num_inference_steps_list'
```

After: all three bind cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
